### PR TITLE
Use auth token at connect

### DIFF
--- a/src/Runly/ResultsChannel.cs
+++ b/src/Runly/ResultsChannel.cs
@@ -61,10 +61,12 @@ namespace Runly
 		/// <returns>A <see cref="Connection"/> to the results hub.</returns>
 		public async Task<Connection> ConnectAsync(Guid instanceId, CancellationToken token = default(CancellationToken))
 		{
+			var authToken = await auth.AcquireToken();
+
 			var connection = new HubConnectionBuilder()
 				.WithUrl(new Uri(baseUri, $"/nodes/results/{instanceId}"), o =>
 				{
-					o.AccessTokenProvider = auth.AcquireToken;
+					o.AccessTokenProvider = () => Task.FromResult(authToken);
 
 					opts?.Invoke(o);
 				})


### PR DESCRIPTION
Uses the auth token that exists when the ResultsChannel connects to the SignalR hub, not the auth token that exists at each subsequent request made by the SignalR internals.