### PR TITLE
Fix Development mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '3.1.100'
 
@@ -29,11 +29,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '3.1.100'
 

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout Main Branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -26,7 +26,7 @@ jobs:
         args: metadata
 
     - name: Checkout docfx Branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: docfx
         path: docfx

--- a/.github/workflows/nuget-prerelease.yml
+++ b/.github/workflows/nuget-prerelease.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '3.1.100'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '3.1.100'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/Runly.sln
+++ b/Runly.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29519.181
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Client", "src\Client\Client.csproj", "{6A5344CC-7B78-4330-9EE9-E5C96EE975E4}"
 EndProject
@@ -12,6 +12,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Diagnostics", "src\Diagnostics\Diagnostics.csproj", "{5EAC3C62-D609-4876-BE38-2A0ABC0A59D9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Runly", "src\Runly\Runly.csproj", "{F74B45FF-BFFB-425C-9CF4-C509402E545E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Runly.Tests.Cli", "test\Runly.Tests.Cli\Runly.Tests.Cli.csproj", "{CAC30475-7E45-43E2-9775-14E6E31C837B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -83,6 +85,18 @@ Global
 		{F74B45FF-BFFB-425C-9CF4-C509402E545E}.Release|x64.Build.0 = Release|Any CPU
 		{F74B45FF-BFFB-425C-9CF4-C509402E545E}.Release|x86.ActiveCfg = Release|Any CPU
 		{F74B45FF-BFFB-425C-9CF4-C509402E545E}.Release|x86.Build.0 = Release|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Debug|x64.Build.0 = Debug|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Debug|x86.Build.0 = Debug|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Release|x64.ActiveCfg = Release|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Release|x64.Build.0 = Release|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Release|x86.ActiveCfg = Release|Any CPU
+		{CAC30475-7E45-43E2-9775-14E6E31C837B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Client/Client.csproj
+++ b/src/Client/Client.csproj
@@ -26,13 +26,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
-    <PackageReference Include="MinVer" Version="2.3.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+	  <PackageReference Include="MinVer" Version="2.3.0">
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		  <PrivateAssets>all</PrivateAssets>
+	  </PackageReference>	  
+	<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Runly/Runly.csproj
+++ b/src/Runly/Runly.csproj
@@ -28,22 +28,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-		<PackageReference Include="Ben.Demystifier" Version="0.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.5" />
+		<PackageReference Include="Ben.Demystifier" Version="0.4.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="MinVer" Version="2.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NJsonSchema" Version="10.1.20" />
+	<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+	<PackageReference Include="NJsonSchema" Version="10.1.20" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20303.1" />
-		<PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Runly.Tests.Cli/Program.cs
+++ b/test/Runly.Tests.Cli/Program.cs
@@ -1,0 +1,5 @@
+﻿using Runly;
+
+await JobHost.CreateDefaultBuilder(args)
+    .Build()
+    .RunJobAsync();

--- a/test/Runly.Tests.Cli/Properties/launchSettings.json
+++ b/test/Runly.Tests.Cli/Properties/launchSettings.json
@@ -1,0 +1,32 @@
+{
+  "profiles": {
+    "WSL": {
+      "commandName": "WSL2",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      },
+      "distributionName": ""
+    },
+    "List": {
+      "commandName": "Project",
+      "commandLineArgs": "list",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    },
+    "Run TestJob": {
+      "commandName": "Project",
+      "commandLineArgs": "TestJob",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    },
+    "Get TestJob": {
+      "commandName": "Project",
+      "commandLineArgs": "list",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/test/Runly.Tests.Cli/Runly.Tests.Cli.csproj
+++ b/test/Runly.Tests.Cli/Runly.Tests.Cli.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Runly\Runly.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Runly.Tests.Cli/TestJob.cs
+++ b/test/Runly.Tests.Cli/TestJob.cs
@@ -1,0 +1,13 @@
+﻿namespace Runly.Tests.Cli;
+public class TestJob : Job<Config>
+{
+    public TestJob(Config config)
+        : base(config) { }
+
+    public override Task<Result> ProcessAsync()
+    {
+        Console.WriteLine("TestJob is running");
+
+        return Task.FromResult(Result.Success());
+    }
+}

--- a/test/Runly.Tests/Runly.Tests.csproj
+++ b/test/Runly.Tests/Runly.Tests.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Runly.Tests/UnitTest.cs
+++ b/test/Runly.Tests/UnitTest.cs
@@ -9,7 +9,7 @@ namespace Runly.Tests
 	{
 		static UnitTest()
 		{
-			AssertionOptions.AssertEquivalencyUsing(opts => opts.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 2000)).WhenTypeIs<DateTime>());
+			AssertionOptions.AssertEquivalencyUsing(opts => opts.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, TimeSpan.FromMilliseconds(2000))).WhenTypeIs<DateTime>());
 		}
 
 		public UnitTest() { }


### PR DESCRIPTION
Fixes unresolvable jobs when `DOTNET_ENVIRONMENT` is set to `Development` (`Environment.IsDevelopment = true`). This was due to the `Host.CreateDefaultBuilder` setting `ServiceProviderOptions.ValidateOnBuild = Environment.IsDevelopment` which then caused the `ServiceProvider` to create an instance of each job registered (all jobs in the `JobCache`). 

This fix no longer adds all jobs in the `JobCache` to the service collection and changes `ServiceExtensions.AddConfig` into `AddJob` which adds the job and config that is being run, therefore passing the service provider validation with all of it's dependencies being present.