### PR TITLE
Register job as scoped

### DIFF
--- a/src/Runly/JobHost.cs
+++ b/src/Runly/JobHost.cs
@@ -133,7 +133,10 @@ namespace Runly
 		/// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
 		public static Task RunJobAsync(this IHost host, CancellationToken cancellationToken)
 		{
-			var action = host.Services.GetService<IHostAction>();
+			using var scope = host.Services.CreateAsyncScope();
+
+            var action = scope.ServiceProvider.GetRequiredService<IHostAction>();
+			
 			return action?.RunAsync(cancellationToken) ?? Task.CompletedTask;
 		}
 	}

--- a/src/Runly/Processing/ExecutionBase.cs
+++ b/src/Runly/Processing/ExecutionBase.cs
@@ -256,7 +256,9 @@ namespace Runly.Processing
 				{
 					try
 					{
-						await ProcessScopeAsync(provider.CreateScope());
+						using var scope = provider.CreateAsyncScope();
+
+                        await ProcessScopeAsync(scope);
 					}
 					catch (Exception ex) when (Job.Config.Execution.HandleExceptions)
 					{
@@ -275,7 +277,7 @@ namespace Runly.Processing
 		/// </summary>
 		/// <param name="scope">The <see cref="IServiceScope"/> containing a scoped <see cref="IServiceProvider"/> to get services from.</param>
 		/// <returns>A <see cref="Task"/> representing the asynchronous execution of this method.</returns>
-		async Task ProcessScopeAsync(IServiceScope scope)
+		async Task ProcessScopeAsync(AsyncServiceScope scope)
 		{
 			bool @continue = true;
 			var stopwatch = new Stopwatch();

--- a/src/Runly/ServiceExtensions.cs
+++ b/src/Runly/ServiceExtensions.cs
@@ -340,7 +340,7 @@ namespace Runly
 				));
 			}
 
-			services.AddSingleton<Execution>(s =>
+			services.AddScoped<Execution>(s =>
 			{
 				var cache = s.GetRequiredService<JobCache>();
 
@@ -369,7 +369,7 @@ namespace Runly
 		{
             var info = cache.Get(config.Job.Type);
 
-            services.AddTransient(info.JobType);
+            services.AddScoped(info.JobType);
 
             var type = config.GetType();
 

--- a/test/Runly.Tests/Dependencies.cs
+++ b/test/Runly.Tests/Dependencies.cs
@@ -1,7 +1,9 @@
 ﻿namespace Runly.Tests
 {
-	public class Dep1 { }
-	public class Dep2 { }
+	public interface IDep1 { }
+	public class Dep1 : IDep1 { }
+	public interface IDep2 { }
+	public class Dep2 : IDep2 { }
 	public class Dep3 { }
 	public class Dep4 { }
 	public class Dep5 { }

--- a/test/Runly.Tests/Jobs.cs
+++ b/test/Runly.Tests/Jobs.cs
@@ -46,7 +46,22 @@ namespace Runly.Tests
 		}
 	}
 
-	public class Job2 : Job<Config, int, Dep1, Dep2>
+    public class Job1WithConstructorDep : Job<Config, int>
+    {
+        public Job1WithConstructorDep(IDep1 dep1) : base(new Config()) { }
+
+        public override IAsyncEnumerable<int> GetItemsAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<Result> ProcessAsync(int item)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class Job2 : Job<Config, int, Dep1, Dep2>
 	{
 		public Job2() : base(new Config()) { }
 
@@ -61,7 +76,22 @@ namespace Runly.Tests
 		}
 	}
 
-	public class Job3 : Job<Config, int, Dep1, Dep2, Dep3>
+    public class Job2WithConstructorDep : Job<Config, int>
+    {
+        public Job2WithConstructorDep(IDep1 dep1, IDep2 dep2) : base(new Config()) { }
+
+        public override IAsyncEnumerable<int> GetItemsAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<Result> ProcessAsync(int item)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class Job3 : Job<Config, int, Dep1, Dep2, Dep3>
 	{
 		public Job3() : base(new Config()) { }
 

--- a/test/Runly.Tests/Scenarios/Running/Running_a_job.cs
+++ b/test/Runly.Tests/Scenarios/Running/Running_a_job.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Runly.Hosting;
 using Runly.Testing;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -34,7 +35,10 @@ namespace Runly.Tests.Scenarios.Running
         [Fact]
         public async Task should_run_a_job_with_scoped_dependency_in_constructor()
         {
-            var builder = JobHost.CreateDefaultBuilder(["Job2WithConstructorDep"])
+			// CreateDefaultBuilder is more strict with Environment = Dev
+			Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", "Development");
+
+            var action = JobHost.CreateDefaultBuilder(["Job1WithConstructorDep"], typeof(UnitTest).Assembly)
                  .ConfigureServices((context, services) =>
                  {
                      services.AddScoped<IDep1>(s => new Dep1());
@@ -42,12 +46,7 @@ namespace Runly.Tests.Scenarios.Running
                  })
                 .Build();
 
-            var action = builder.Services.GetRequiredService<IHostAction>();
-
-            action.Should().NotBeNull()
-                .And.BeOfType<RunAction>();
-
-            await action.RunAsync();
+            await action.RunJobAsync();
         }
     }
 }

--- a/test/Runly.Tests/Scenarios/Running/Running_a_job.cs
+++ b/test/Runly.Tests/Scenarios/Running/Running_a_job.cs
@@ -1,4 +1,6 @@
 ﻿using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Runly.Hosting;
 using Runly.Testing;
 using System.Threading.Tasks;
 using Xunit;
@@ -28,5 +30,24 @@ namespace Runly.Tests.Scenarios.Running
 			runner.Execution.IsComplete.Should().BeTrue();
 			runner.Execution.Disposition.Should().Be(Disposition.Successful);
 		}
-	}
+
+        [Fact]
+        public async Task should_run_a_job_with_scoped_dependency_in_constructor()
+        {
+            var builder = JobHost.CreateDefaultBuilder(["Job2WithConstructorDep"])
+                 .ConfigureServices((context, services) =>
+                 {
+                     services.AddScoped<IDep1>(s => new Dep1());
+					 services.AddSingleton<IDep2>(s => new Dep2());
+                 })
+                .Build();
+
+            var action = builder.Services.GetRequiredService<IHostAction>();
+
+            action.Should().NotBeNull()
+                .And.BeOfType<RunAction>();
+
+            await action.RunAsync();
+        }
+    }
 }


### PR DESCRIPTION
- Registers the job and execution as `scoped` so that the job constructor can take scoped dependencies when `Environment.IsDevelopment = true` and service validation is a enabled.
- Creates a scope to get the execution
- Uses `AsyncServiceScope` for the job and concurrent tasks